### PR TITLE
Separate Summary from Report

### DIFF
--- a/src/main/kotlin/org/dbtools/licensemanager/LicenseManagerExtension.kt
+++ b/src/main/kotlin/org/dbtools/licensemanager/LicenseManagerExtension.kt
@@ -26,6 +26,13 @@ open class LicenseManagerExtension @Inject constructor(
     var outputDirs: List<String> = listOf(defaultOutputDir)
 
     /**
+     * Default summary directory
+     */
+    @get:Optional
+    @get:Input
+    var summaryDirs: List<String> = listOf(defaultOutputDir)
+
+    /**
      * Name of file without extension
      */
     @get:Input

--- a/src/main/kotlin/org/dbtools/licensemanager/ReportTask.kt
+++ b/src/main/kotlin/org/dbtools/licensemanager/ReportTask.kt
@@ -46,7 +46,8 @@ open class ReportTask @Inject constructor(
             if (extension.createCsvReport) {
                 generateLicenceReportCsv(poms, File(dir, "${extension.outputFilename}.csv"))
             }
-
+        }
+        getOutputDirs(extension.summaryDirs).forEach { dir ->
             generateSummaryReportHtml(poms, File(dir, "license-summary.html"))
         }
     }


### PR DESCRIPTION
Currently the summary is written to the same outputs as the report which causes it to be bundled in with the app.